### PR TITLE
Ops 5102

### DIFF
--- a/app/auth/Actions.scala
+++ b/app/auth/Actions.scala
@@ -19,13 +19,6 @@ package auth
 import com.google.inject.Inject
 import play.api.mvc._
 
-import scala.concurrent.ExecutionContext
-
-class Actions @Inject() (
-    authoriseAction: AuthenticatedAction,
-    actionBuilder:   DefaultActionBuilder)(implicit ec: ExecutionContext) {
-
-  def strideAuthenticateAction(): ActionBuilder[Request, AnyContent] = {
-    actionBuilder andThen authoriseAction
-  }
+class Actions @Inject() (authoriseAction: AuthenticatedAction, actionBuilder: DefaultActionBuilder) {
+  def strideAuthenticateAction(): ActionBuilder[Request, AnyContent] = actionBuilder andThen authoriseAction
 }

--- a/app/auth/UnhappyPathResponses.scala
+++ b/app/auth/UnhappyPathResponses.scala
@@ -16,15 +16,10 @@
 
 package auth
 
-import javax.inject.Singleton
-import play.api.mvc.{Request, Result}
+import play.api.mvc.Result
 import play.api.mvc.Results.Unauthorized
 
-@Singleton
-class UnhappyPathResponses {
-
-  def unauthorised(implicit request: Request[_]): Result = Unauthorized("You do not have access to this service")
-
-  def notLoggedIn(implicit request: Request[_]): Result = Unauthorized("You are not logged in")
-
+object UnhappyPathResponses {
+  val unauthorised: Result = Unauthorized("You do not have access to this service")
+  val notLoggedIn: Result = Unauthorized("You are not logged in")
 }

--- a/app/controllers/TestController.scala
+++ b/app/controllers/TestController.scala
@@ -31,11 +31,11 @@ class TestController @Inject() (cc: ControllerComponents, tpsRepo: TpsRepo)(impl
   val possibleReferences = Seq("TT999991", "TT999992", "TT999993", "TT999994",
     "TT999995", "TT999996", "TT999997", "TT999998", "TT999999")
 
-  def removeTestData(): Action[AnyContent] = Action.async { implicit request =>
+  def removeTestData(): Action[AnyContent] = Action.async {
     tpsRepo.removeByReferenceForTest(possibleReferences.toList).map(_ => Ok("Test data removed"))
   }
 
-  def findByReference(ref: String): Action[AnyContent] = Action.async { implicit request =>
+  def findByReference(ref: String): Action[AnyContent] = Action.async {
     tpsRepo.findByReferenceForTest(ref).map(result => Ok(toJson(result)))
   }
 

--- a/app/controllers/TpsController.scala
+++ b/app/controllers/TpsController.scala
@@ -41,7 +41,7 @@ class TpsController @Inject() (actions: Actions,
     }
   }
 
-  def findTpsPayments(id: TpsId): Action[AnyContent] = actions.strideAuthenticateAction().async { implicit request =>
+  def findTpsPayments(id: TpsId): Action[AnyContent] = actions.strideAuthenticateAction().async {
     Logger.debug(s"findTpsPayments received vrn $id")
 
     tpsRepo.findPayment(id).map {
@@ -50,12 +50,12 @@ class TpsController @Inject() (actions: Actions,
     }
   }
 
-  def getId: Action[AnyContent] = actions.strideAuthenticateAction().async { implicit request =>
+  def getId: Action[AnyContent] = actions.strideAuthenticateAction().async {
     Logger.debug(s"getId")
     Future.successful(Ok(toJson(TpsId.fresh)))
   }
 
-  def delete(tpsId: TpsId): Action[AnyContent] = actions.strideAuthenticateAction().async { implicit request =>
+  def delete(tpsId: TpsId): Action[AnyContent] = actions.strideAuthenticateAction().async {
     Logger.debug(s"delete, id= ${tpsId.value}")
     tpsRepo.removeById(tpsId).map(_ => Ok)
   }

--- a/app/model/IdNotFoundException.scala
+++ b/app/model/IdNotFoundException.scala
@@ -14,20 +14,6 @@
  * limitations under the License.
  */
 
-package support
+package model
 
-import org.scalatest._
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
-
-trait RichMatchers
-  extends Matchers
-  with DiagrammedAssertions
-  with TryValues
-  with EitherValues
-  with OptionValues
-  with AppendedClues
-  with ScalaFutures
-  with StreamlinedXml
-  with Inside
-  with Eventually
-  with IntegrationPatience
+class IdNotFoundException(message: String) extends RuntimeException(message)

--- a/app/repository/Repo.scala
+++ b/app/repository/Repo.scala
@@ -19,18 +19,16 @@ package repository
 import play.api.libs.json._
 import play.modules.reactivemongo.ReactiveMongoComponent
 import reactivemongo.api.commands.UpdateWriteResult
-import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.ReactiveRepository
 
 import scala.concurrent.{ExecutionContext, Future}
 
 abstract class Repo[A, ID](
     collectionName:         String,
-    reactiveMongoComponent: ReactiveMongoComponent)(implicit manifest: Manifest[A],
-                                                    mid:              Manifest[ID],
-                                                    domainFormat:     OFormat[A],
-                                                    idFormat:         Format[ID],
-                                                    executionContext: ExecutionContext)
+    reactiveMongoComponent: ReactiveMongoComponent)
+  (implicit domainFormat: OFormat[A],
+   idFormat:         Format[ID],
+   executionContext: ExecutionContext)
   extends ReactiveRepository[A, ID](
     collectionName,
     reactiveMongoComponent.mongoConnector.db,
@@ -44,7 +42,7 @@ abstract class Repo[A, ID](
   /**
    * Update or Insert (UpSert)
    */
-  def upsert(id: ID, a: A)(implicit hc: HeaderCarrier): Future[UpdateWriteResult] = collection.update(ordered = false).one(
+  def upsert(id: ID, a: A): Future[UpdateWriteResult] = collection.update(ordered = false).one(
     _id(id),
     a,
     upsert = true

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
-import uk.gov.hmrc.DefaultBuildSettings.integrationTestSettings
+import sbt.Tests.{Group, SubProcess}
+import uk.gov.hmrc.DefaultBuildSettings.{defaultSettings, integrationTestSettings, scalaSettings}
 import uk.gov.hmrc.SbtArtifactory
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
+import wartremover.{Wart, wartremoverErrors, wartremoverExcluded}
 
 val appName = "tps-payments-backend"
 
@@ -18,9 +20,14 @@ lazy val microservice = Project(appName, file("."))
   .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(
-    majorVersion := 0,
-    libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test
+    resolvers                        ++= Seq(Resolver.bintrayRepo("hmrc", "releases"), Resolver.jcenterRepo),
+    libraryDependencies              ++= AppDependencies.compile ++ AppDependencies.test,
+    retrieveManaged                  :=  true,
+    routesGenerator                  :=  InjectedRoutesGenerator,
+    evictionWarningOptions in update :=  EvictionWarningOptions.default.withWarnScalaVersionEviction(false)
   )
+  .settings(scalaVersion := "2.12.11")
+  .settings(majorVersion := 1)
   .settings(ScalariformSettings())
   .settings(ScoverageSettings())
   .settings(WartRemoverSettings.wartRemoverError)
@@ -28,14 +35,16 @@ lazy val microservice = Project(appName, file("."))
   .settings(wartremoverErrors in(Test, compile) --= Seq(Wart.Any, Wart.Equals, Wart.Null, Wart.NonUnitStatements, Wart.PublicInference))
   .settings(wartremoverExcluded ++=
     routes.in(Compile).value ++
-      (baseDirectory.value / "it").get ++
       (baseDirectory.value / "test").get ++
       Seq(sourceManaged.value / "main" / "sbt-buildinfo" / "BuildInfo.scala"))
   .settings(publishingSettings: _*)
-  .configs(IntegrationTest)
-  .settings(integrationTestSettings(): _*)
-  .settings(resolvers += Resolver.jcenterRepo)
   .settings(PlayKeys.playDefaultPort := 9125)
+  .settings(scalaSettings: _*)
+  .settings(defaultSettings(): _*)
+  .settings(integrationTestSettings())
+  .configs(IntegrationTest)
+  .settings(resolvers += Resolver.jcenterRepo)
+  .settings(resolvers += Resolver.jcenterRepo)
   .settings(
     routesImport ++= Seq(
       "model._"

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,10 +6,9 @@ import sbt._
 object AppDependencies {
 
   val compile = Seq(
-
-    "uk.gov.hmrc"             %% "simple-reactivemongo"     % "7.26.0-play-26",
-    "uk.gov.hmrc"             %% "bootstrap-play-26"        % "1.7.0",
-    "com.beachape"            %% "enumeratum"               % "1.5.13"
+    "uk.gov.hmrc" %% "simple-reactivemongo" % "7.30.0-play-26",
+    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.14.0",
+    "com.beachape" %% "enumeratum" % "1.5.13"
   )
 
   val test = Seq(

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -13,7 +13,6 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc" %% "bootstrap-play-26" % "1.7.0" % Test,
     "org.scalatest" %% "scalatest" % "3.0.8" % Test,
     "com.typesafe.play" %% "play-test" % current % Test,
     "org.pegdown" % "pegdown" % "1.6.0" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.13

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,15 +2,13 @@ resolvers += Resolver.url("HMRC Sbt Plugin Releases", url("https://dl.bintray.co
   Resolver.ivyStylePatterns)
 
 resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
-
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.2.0")
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.6.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.0.0")
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.24")
-
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.23")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.3.7")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.2")

--- a/test/controllers/TpsControllerSpec.scala
+++ b/test/controllers/TpsControllerSpec.scala
@@ -19,103 +19,90 @@ package controllers
 import model.PaymentItemId
 import model.pcipal.PcipalSessionId
 import play.api.http.Status
-import reactivemongo.api.commands.UpdateWriteResult
-import repository.TpsRepo
-import support.{AuthWireMockResponses, ItSpec, TestConnector, TpsData}
+import support.TpsData.{chargeRefNotificationPciPalRequest, id, tpsPayments}
+import support.{AuthWireStub, ItSpec, TestConnector, TpsData}
 
-class TpsControllerSpec extends ItSpec {
-
-  val repo: TpsRepo = injector.instanceOf[TpsRepo]
-  val testConnector = injector.instanceOf[TestConnector]
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    val remove = repo.removeAll().futureValue
-  }
+class TpsControllerSpec extends ItSpec with Status {
+  private lazy val connector = injector.instanceOf[TestConnector]
 
   "store data when authorised" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val result = testConnector.store(TpsData.tpsPayments).futureValue
-    result shouldBe TpsData.id
+    AuthWireStub.authorised()
+    val result = connector.store(tpsPayments).futureValue
+    result shouldBe id
   }
 
   "store data and delete when authorised" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val result = testConnector.store(TpsData.tpsPayments).futureValue
-    result shouldBe TpsData.id
-    val resultDelete = testConnector.delete(TpsData.id).futureValue
-    resultDelete.status shouldBe Status.OK
+    AuthWireStub.authorised()
+    val result = connector.store(tpsPayments).futureValue
+    result shouldBe id
+    val resultDelete = connector.delete(id).futureValue
+    resultDelete.status shouldBe OK
 
   }
   "getId" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val result = testConnector.getId.futureValue
-    result.status shouldBe Status.OK
+    AuthWireStub.authorised()
+    val result = connector.getId.futureValue
+    result.status shouldBe OK
   }
 
   "Not authorised should get an exception" in {
-    AuthWireMockResponses.notAuthorised
-    an[Exception] should be thrownBy testConnector.store(TpsData.tpsPayments).futureValue
+    AuthWireStub.notAuthorised
+    an[Exception] should be thrownBy connector.store(tpsPayments).futureValue
   }
 
   "Insufficient Enrolments should get an exception" in {
-    AuthWireMockResponses.failsWith("InsufficientEnrolments")
-    an[Exception] should be thrownBy testConnector.store(TpsData.tpsPayments).futureValue
+    AuthWireStub.failsWith("InsufficientEnrolments")
+    an[Exception] should be thrownBy connector.store(tpsPayments).futureValue
   }
 
   "Check that TpsData can be found" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val upserted: UpdateWriteResult = repo.upsert(TpsData.id, TpsData.tpsPayments).futureValue
-    upserted.n shouldBe 1
-    val result = testConnector.find(TpsData.id).futureValue
-    result shouldBe TpsData.tpsPayments
+    AuthWireStub.authorised()
+    repo.upsert(id, tpsPayments).futureValue.n shouldBe 1
+    val result = connector.find(id).futureValue
+    result shouldBe tpsPayments
   }
 
   "Check that TpsData cannot be found" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val result = testConnector.find(TpsData.id).failed.futureValue
-    result.getMessage should include(s"No payments found for id ${TpsData.id.value}")
+    AuthWireStub.authorised()
+    val result = connector.find(id).failed.futureValue
+    result.getMessage should include(s"No payments found for id ${id.value}")
   }
 
   "Check that TpsData can be updated with pcipal-sessionId" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val upserted: UpdateWriteResult = repo.upsert(TpsData.id, TpsData.tpsPayments.copy(pciPalSessionId = None)).futureValue
-    upserted.n shouldBe 1
-    val result = testConnector.find(TpsData.id).futureValue
-    result shouldBe TpsData.tpsPayments.copy(pciPalSessionId = None)
+    AuthWireStub.authorised()
+    repo.upsert(id, tpsPayments.copy(pciPalSessionId = None)).futureValue.n shouldBe 1
+    val result = connector.find(id).futureValue
+    result shouldBe tpsPayments.copy(pciPalSessionId = None)
     result.pciPalSessionId shouldBe None
-    val updated = testConnector.updateWithSessionId(TpsData.id, TpsData.pciPalSessionId).futureValue
-    val result2 = testConnector.find(TpsData.id).futureValue
+    connector.updateWithSessionId(id, TpsData.pciPalSessionId).futureValue
+    val result2 = connector.find(id).futureValue
     result2.pciPalSessionId shouldBe Some(TpsData.pciPalSessionId)
 
   }
 
   "update with pci-pal data" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val upserted: UpdateWriteResult = repo.upsert(TpsData.id, TpsData.tpsPayments).futureValue
-    upserted.n shouldBe 1
-    val pciPaledUpdated = testConnector.updateTpsPayments(TpsData.chargeRefNotificationPciPalRequest).futureValue
-    pciPaledUpdated.status shouldBe Status.OK
-    val result = testConnector.find(TpsData.id).futureValue
-    result.payments(0).pcipalData match {
-      case Some(x) => x shouldBe TpsData.chargeRefNotificationPciPalRequest
+    AuthWireStub.authorised()
+    repo.upsert(id, tpsPayments).futureValue.n shouldBe 1
+    val pciPaledUpdated = connector.updateTpsPayments(chargeRefNotificationPciPalRequest).futureValue
+    pciPaledUpdated.status shouldBe OK
+    val result = connector.find(id).futureValue
+    result.payments.head.pcipalData match {
+      case Some(x) => x shouldBe chargeRefNotificationPciPalRequest
       case None    => throw new RuntimeException("Pcipal data missing")
     }
   }
 
   "get an exception if pcipalSessionId not found and trying to do an update" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val upserted: UpdateWriteResult = repo.upsert(TpsData.id, TpsData.tpsPayments).futureValue
-    upserted.n shouldBe 1
-    val error = testConnector.updateTpsPayments(TpsData.chargeRefNotificationPciPalRequest.copy(PCIPalSessionId = PcipalSessionId("new)"))).failed.futureValue
+    AuthWireStub.authorised()
+    repo.upsert(id, tpsPayments).futureValue.n shouldBe 1
+    val error = connector.updateTpsPayments(chargeRefNotificationPciPalRequest.copy(PCIPalSessionId = PcipalSessionId("new)"))).failed.futureValue
     error.getMessage should include ("Could not find pcipalSessionId: new")
   }
 
   "get an exception if paymentItemId not found and trying to do an update" in {
-    AuthWireMockResponses.authorised("PrivilegedApplication", "userId")
-    val upserted: UpdateWriteResult = repo.upsert(TpsData.id, TpsData.tpsPayments).futureValue
-    upserted.n shouldBe 1
-    val error = testConnector.updateTpsPayments(TpsData.chargeRefNotificationPciPalRequest.copy(paymentItemId = PaymentItemId("New"))).failed.futureValue
+    AuthWireStub.authorised()
+    repo.upsert(id, tpsPayments).futureValue.n shouldBe 1
+    val error = connector.updateTpsPayments(chargeRefNotificationPciPalRequest.copy(paymentItemId = PaymentItemId("New"))).failed.futureValue
     error.getMessage should include ("Could not find paymentItemId: New")
   }
 

--- a/test/model/ChargeRefNotificationPciPalRequestSpec.scala
+++ b/test/model/ChargeRefNotificationPciPalRequestSpec.scala
@@ -17,13 +17,13 @@
 package model
 
 import model.pcipal.ChargeRefNotificationPcipalRequest
-import play.api.libs.json.Json
+import play.api.libs.json.Json.toJson
 import support.{TpsData, UnitSpec}
 
 class ChargeRefNotificationPciPalRequestSpec extends UnitSpec {
 
   "to json" in {
-    Json.toJson(TpsData.chargeRefNotificationPciPalRequest) shouldBe TpsData.chargeRefNotificationPciPalRequestJson
+    toJson(TpsData.chargeRefNotificationPciPalRequest) shouldBe TpsData.chargeRefNotificationPciPalRequestJson
   }
 
   "from json" in {

--- a/test/model/StatusTypesSpec.scala
+++ b/test/model/StatusTypesSpec.scala
@@ -16,7 +16,9 @@
 
 package model
 
-import play.api.libs.json.{JsString, Json}
+import model.StatusTypes.{failed, validated}
+import play.api.libs.json.JsString
+import play.api.libs.json.Json.toJson
 import support.UnitSpec
 
 class StatusTypesSpec extends UnitSpec {
@@ -24,12 +26,12 @@ class StatusTypesSpec extends UnitSpec {
   "de/serialize TaxTypes" in {
 
     val statusTypes = List(
-      "validated" -> StatusTypes.validated,
-      "failed" -> StatusTypes.failed
+      "validated" -> validated,
+      "failed" -> failed
     )
 
     statusTypes.foreach { tt =>
-      val jsValue = Json.toJson(tt._2)
+      val jsValue = toJson(tt._2)
       jsValue shouldBe JsString(tt._1) withClue s"serialize $tt"
       jsValue.as[StatusType] shouldBe tt._2 withClue s"deserialize $tt"
     }

--- a/test/model/TpsPaymentsSpec.scala
+++ b/test/model/TpsPaymentsSpec.scala
@@ -32,16 +32,17 @@ package model
  * limitations under the License.
  */
 
-import play.api.libs.json.Json
-import support.{TpsData, UnitSpec}
+import play.api.libs.json.Json.toJson
+import support.TpsData.{tpsPayments, tpsPaymentsJson}
+import support.UnitSpec
 
 class TpsPaymentsSpec extends UnitSpec {
 
   "to json" in {
-    Json.toJson(TpsData.tpsPayments) shouldBe TpsData.tpsPaymentsJson
+    toJson(tpsPayments) shouldBe tpsPaymentsJson
   }
 
   "from json" in {
-    TpsData.tpsPaymentsJson.as[TpsPayments] shouldBe TpsData.tpsPayments
+    tpsPaymentsJson.as[TpsPayments] shouldBe tpsPayments
   }
 }

--- a/test/repository/TpsRepoSpec.scala
+++ b/test/repository/TpsRepoSpec.scala
@@ -21,28 +21,19 @@ import reactivemongo.api.commands.UpdateWriteResult
 import support.{ItSpec, TpsData}
 
 class TpsRepoSpec extends ItSpec {
-
-  val repo: TpsRepo = injector.instanceOf[TpsRepo]
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    val remove = repo.removeAll().futureValue
-  }
-
   "Count should be 0 with empty repo" in {
     collectionSize shouldBe 0
   }
 
   "ensure indexes are created" in {
-
-    val remove = repo.drop.futureValue
-    val ensure = repo.ensureIndexes.futureValue
+    repo.drop.futureValue
+    repo.ensureIndexes.futureValue
     repo.collection.indexesManager.list().futureValue.size shouldBe 3
   }
 
   "insert a record" in {
-    val upserted: UpdateWriteResult = repo.upsert(TpsData.id, TpsData.tpsPayments).futureValue
-    upserted.n shouldBe 1
+    val result: UpdateWriteResult = repo.upsert(TpsData.id, TpsData.tpsPayments).futureValue
+    result.n shouldBe 1
   }
 
   private def collectionSize: Int = {

--- a/test/support/AuthStub.scala
+++ b/test/support/AuthStub.scala
@@ -19,10 +19,10 @@ package support
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
-object AuthWireStub {
-  val expectedDetail = "SessionRecordNotFound"
+object AuthStub {
+  private val expectedDetail = "SessionRecordNotFound"
 
-  def notAuthorised: StubMapping =
+  def givenTheUserIsNotAuthenticated(): StubMapping =
     stubFor(post(urlEqualTo("/auth/authorise"))
       .willReturn(aResponse()
         .withStatus(401)
@@ -30,7 +30,7 @@ object AuthWireStub {
       )
     )
 
-  def authorised(): StubMapping =
+  def givenTheUserIsAuthenticatedAndAuthorised(): StubMapping =
     stubFor(post(urlEqualTo("/auth/authorise"))
       .withRequestBody(
         equalToJson(
@@ -55,7 +55,7 @@ object AuthWireStub {
                     {"allEnrolments":[{"key":"digital_tps_payment_taker_call_handler","identifiers":[],"state":"activated"}]}
        """.stripMargin)))
 
-  def failsWith(error: String): StubMapping =
+  def givenTheUserIsNotAuthorised(error: String): StubMapping =
     stubFor(post(urlEqualTo("/auth/authorise"))
       .willReturn(aResponse()
         .withStatus(401)

--- a/test/support/AuthWireStub.scala
+++ b/test/support/AuthWireStub.scala
@@ -19,20 +19,18 @@ package support
 import com.github.tomakehurst.wiremock.client.WireMock._
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 
-object AuthWireMockResponses {
-
+object AuthWireStub {
   val expectedDetail = "SessionRecordNotFound"
 
-  def notAuthorised: StubMapping = {
+  def notAuthorised: StubMapping =
     stubFor(post(urlEqualTo("/auth/authorise"))
       .willReturn(aResponse()
         .withStatus(401)
         .withHeader("WWW-Authenticate", s"""MDTP detail="$expectedDetail"""")
       )
     )
-  }
 
-  def authorised(authProvider: String, strideUserId: String): StubMapping = {
+  def authorised(): StubMapping =
     stubFor(post(urlEqualTo("/auth/authorise"))
       .withRequestBody(
         equalToJson(
@@ -42,7 +40,7 @@ object AuthWireMockResponses {
                "authorise": [
                  {
                    "authProviders": [
-                     "$authProvider"
+                     "PrivilegedApplication"
                    ]
                  }
                ],
@@ -57,15 +55,12 @@ object AuthWireMockResponses {
                     {"allEnrolments":[{"key":"digital_tps_payment_taker_call_handler","identifiers":[],"state":"activated"}]}
        """.stripMargin)))
 
-  }
-
-  def failsWith(error: String): StubMapping = {
+  def failsWith(error: String): StubMapping =
     stubFor(post(urlEqualTo("/auth/authorise"))
       .willReturn(aResponse()
         .withStatus(401)
         .withHeader("WWW-Authenticate", s"""MDTP detail="$error"""")
       )
     )
-  }
 
 }

--- a/test/support/ItSpec.scala
+++ b/test/support/ItSpec.scala
@@ -42,7 +42,6 @@ import play.api.inject.Injector
 import play.api.inject.guice.{GuiceApplicationBuilder, GuiceableModule}
 import play.api.mvc.Result
 import repository.TpsRepo
-import uk.gov.hmrc.http.HeaderCarrier
 
 import scala.concurrent.ExecutionContext
 
@@ -59,7 +58,6 @@ trait ItSpec
   with Matchers {
 
   implicit lazy val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
-  implicit val emptyHC: HeaderCarrier = HeaderCarrier()
 
   override implicit val patienceConfig: PatienceConfig = PatienceConfig(
     timeout  = scaled(Span(3, Seconds)),

--- a/test/support/TestConnector.scala
+++ b/test/support/TestConnector.scala
@@ -27,8 +27,8 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class TestConnector @Inject() (httpClient: HttpClient)(implicit executionContext: ExecutionContext) {
 
-  val port = 19001
-  val headers: Seq[(String, String)] = Seq(("Content-Type", "application/json"))
+  private val port = 19001
+  private val headers: Seq[(String, String)] = Seq(("Content-Type", "application/json"))
 
   def store(tpsPayments: TpsPayments)(implicit hc: HeaderCarrier): Future[TpsId] =
     httpClient.POST[TpsPayments, TpsId](s"http://localhost:$port/tps-payments-backend/store", tpsPayments, headers)

--- a/test/support/TestConnector.scala
+++ b/test/support/TestConnector.scala
@@ -21,7 +21,7 @@ import model.pcipal.{ChargeRefNotificationPcipalRequest, PcipalSessionId}
 import model.{TpsId, TpsPayments, UpdateRequest}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.HttpClient
-
+import uk.gov.hmrc.http.HttpReads.Implicits.{readFromJson, readRaw}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/test/support/TpsData.scala
+++ b/test/support/TpsData.scala
@@ -18,25 +18,39 @@ package support
 
 import java.time.LocalDateTime
 
+import model.StatusTypes.validated
 import model._
 import model.pcipal.{ChargeRefNotificationPcipalRequest, PcipalSessionId}
 import play.api.libs.json.{JsValue, Json}
 
 object TpsData {
+  private val created: LocalDateTime = LocalDateTime.parse("2020-01-20T11:56:46")
+  private val paymentId: PaymentItemId = PaymentItemId("session-48c978bb-64b6-4a00-a1f1-51e267d84f91")
+  private val reference = "JE231111"
+  private val reference2 = "B"
+  private val reference3 = "P800"
+  private val pid = "123"
+  private val transReference = "51e267d84f91"
 
-  val created: LocalDateTime = LocalDateTime.parse("2020-01-20T11:56:46")
   val id: TpsId = TpsId("session-48c978bb-64b6-4a00-a1f1-51e267d84f91")
-  val paymentId: PaymentItemId = PaymentItemId("session-48c978bb-64b6-4a00-a1f1-51e267d84f91")
   val pciPalSessionId: PcipalSessionId = PcipalSessionId("48c978bb")
-  val reference = "JE231111"
-  val reference2 = "B"
-  val reference3 = "P800"
-  val pid = "123"
-  val transReference = "51e267d84f91"
 
-  val tpspaymentItemP800: PaymentSpecificDataP800 = PaymentSpecificDataP800(reference, reference2, reference3, 2000)
-  val tpsPayment: TpsPaymentItem = TpsPaymentItem(Some(paymentId), 1.92, HeadOfDutyIndicators.B, created, "AR", "", None, tpspaymentItemP800)
-  val tpsPayments: TpsPayments = TpsPayments(id, pid, Some(pciPalSessionId), created, List(tpsPayment))
+  val tpsPayments: TpsPayments =
+    TpsPayments(
+      id,
+      pid,
+      Some(pciPalSessionId),
+      created,
+      List(
+        TpsPaymentItem(
+          Some(paymentId),
+          1.92,
+          HeadOfDutyIndicators.B,
+          created,
+          "AR",
+          "",
+          None,
+          PaymentSpecificDataP800(reference, reference2, reference3, 2000))))
 
   val chargeRefNotificationPciPalRequest: ChargeRefNotificationPcipalRequest = ChargeRefNotificationPcipalRequest(
     HeadOfDutyIndicators.B,
@@ -44,7 +58,7 @@ object TpsData {
     1.92,
     1.23,
     "VISA",
-    StatusTypes.validated,
+    validated,
     pciPalSessionId,
     transReference,
     paymentId
@@ -58,7 +72,7 @@ object TpsData {
             "Amount": 1.92,
             "Commission": 1.23,
             "CardType": "VISA",
-            "Status": "${StatusTypes.validated.toString}",
+            "Status": "${validated.toString}",
             "PCIPalSessionId": "${pciPalSessionId.value}",
             "TransactionReference": "$transReference",
             "paymentItemId": "${paymentId.value}",
@@ -68,28 +82,28 @@ object TpsData {
   //language=JSON
   val tpsPaymentsJson: JsValue = Json.parse(
     s"""{
-        "_id" : "${id.value}",
-        "pid" : "$pid",
-        "pciPalSessionId" : "${pciPalSessionId.value}",
-        "created":  "$created",
-       "payments": [
-        {
-         "paymentItemId" : "${paymentId.value}",
-        "amount": 1.92,
-        "headOfDutyIndicator": "B",
-        "updated": "$created",
-         "customerName" : "AR",
-         "chargeReference" : "",
-         "paymentSpecificData" : {
-            "ninoPart1": "$reference",
-            "ninoPart2": "$reference2",
-            "taxTypeScreenValue": "$reference3",
-            "period": 2000
-         }
-        }
-        ]
+          "_id" : "${id.value}",
+          "pid" : "$pid",
+          "pciPalSessionId" : "${pciPalSessionId.value}",
+          "created":  "$created",
+          "payments": [
+            {
+              "paymentItemId" : "${paymentId.value}",
+              "amount": 1.92,
+              "headOfDutyIndicator": "B",
+              "updated": "$created",
+              "customerName" : "AR",
+              "chargeReference" : "",
+              "paymentSpecificData" :
+              {
+                "ninoPart1": "$reference",
+                "ninoPart2": "$reference2",
+                "taxTypeScreenValue": "$reference3",
+                "period": 2000
+              }
+            }
+          ]
         }
      """.stripMargin
   )
-
 }

--- a/test/support/UnitSpec.scala
+++ b/test/support/UnitSpec.scala
@@ -16,11 +16,9 @@
 
 package support
 
-import org.scalatest.FreeSpecLike
+import org.scalatest.{AppendedClues, FreeSpecLike, Matchers}
 
 /**
  * This is common spec for every test case which brings all of useful routines we want to use in our scenarios.
  */
-trait UnitSpec
-  extends FreeSpecLike
-  with RichMatchers
+trait UnitSpec extends FreeSpecLike with Matchers with AppendedClues

--- a/test/support/WireMockSupport.scala
+++ b/test/support/WireMockSupport.scala
@@ -25,8 +25,6 @@ trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfterEach {
   self: Suite =>
 
   private val wireMockServer: WireMockServer = new WireMockServer(wireMockConfig().port(WireMockSupport.port))
-  private val wireMockHost = "localhost"
-  private val wireMockBaseUrlAsString = s"http://$wireMockHost:$WireMockSupport.port"
 
   WireMock.configureFor(WireMockSupport.port)
 

--- a/test/support/WireMockSupport.scala
+++ b/test/support/WireMockSupport.scala
@@ -18,16 +18,15 @@ package support
 
 import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.WireMock
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 
 trait WireMockSupport extends BeforeAndAfterAll with BeforeAndAfterEach {
   self: Suite =>
 
-  implicit val wireMockServer: WireMockServer = new WireMockServer(WireMockConfiguration.wireMockConfig().port(WireMockSupport.port))
-  val wireMockHost = "localhost"
-
-  val wireMockBaseUrlAsString = s"http://$wireMockHost:$WireMockSupport.port"
+  private val wireMockServer: WireMockServer = new WireMockServer(wireMockConfig().port(WireMockSupport.port))
+  private val wireMockHost = "localhost"
+  private val wireMockBaseUrlAsString = s"http://$wireMockHost:$WireMockSupport.port"
 
   WireMock.configureFor(WireMockSupport.port)
 


### PR DESCRIPTION
Because 404s are explicitly thrown rather than passed-through from a dependent service this doesn't seem to have the same issues as payments-orchestrator. 

